### PR TITLE
Retina fixes.

### DIFF
--- a/DSFingerTipWindow.m
+++ b/DSFingerTipWindow.m
@@ -124,7 +124,7 @@
     {
         UIBezierPath *clipPath = [UIBezierPath bezierPathWithRect:CGRectMake(0, 0, 50.0, 50.0)];
         
-        UIGraphicsBeginImageContext(clipPath.bounds.size);
+        UIGraphicsBeginImageContextWithOptions(clipPath.bounds.size, NO, 0);
 
         UIBezierPath *drawPath = [UIBezierPath bezierPathWithArcCenter:CGPointMake(25.0, 25.0) 
                                                                 radius:22.0


### PR DESCRIPTION
Use UIGraphicsBeginImageContextWithOptions so that we can an image with the appropriate scale on Retina devices.
