### PR TITLE
Test touchView class instead of assert

### DIFF
--- a/DSFingerTipWindow.m
+++ b/DSFingerTipWindow.m
@@ -262,7 +262,8 @@
 
     for (DSFingerTipView *touchView in [self.overlayWindow subviews])
     {
-        NSAssert([touchView isKindOfClass:[DSFingerTipView class]], @"Unexpected touch view.");
+        if ( ! [touchView isKindOfClass:[DSFingerTipView class]])
+            continue;
         
         if (touchView.shouldAutomaticallyRemoveAfterTimeout && now > touchView.timestamp + REMOVAL_DELAY)
             [self removeFingerTipWithHash:touchView.tag animated:YES];
@@ -275,10 +276,8 @@
 - (void)removeFingerTipWithHash:(NSUInteger)hash animated:(BOOL)animated;
 {
     DSFingerTipView *touchView = (DSFingerTipView *)[self.overlayWindow viewWithTag:hash];
-    if (touchView == nil)
+    if ( ! [touchView isKindOfClass:[DSFingerTipView class]])
         return;
-    
-    NSAssert([touchView isKindOfClass:[DSFingerTipView class]], @"Unexpected touch view.");
     
     if ([touchView isFadingOut])
         return;


### PR DESCRIPTION
It might happen that other views are added as subviews of the key window, e.g. https://github.com/defagos/CoconutKit/blob/2.0.2/CoconutKit/Sources/Animation/HLSLayerAnimationStep.m#L90
So it is better to just test rather than assert in order not to crash.
