### PR TITLE
Podspec update

### DIFF
--- a/Fingertips.podspec
+++ b/Fingertips.podspec
@@ -3,11 +3,12 @@ Pod::Spec.new do |f|
   f.name    = 'Fingertips'
   f.version = '0.3.0'
 
-  f.summary     = 'Touch indicators on external displays for iOS applications.'
-  f.description = 'A UIWindow subclass that gives you automatic presentation mode in your iOS app.'
-  f.homepage    = 'https://github.com/mapbox/Fingertips'
-  f.license     = 'BSD'
-  f.author      = { 'Mapbox' => 'mobile@mapbox.com' }
+  f.summary          = 'Touch indicators on external displays for iOS applications.'
+  f.description      = 'A UIWindow subclass that gives you automatic presentation mode in your iOS app.'
+  f.homepage         = 'https://github.com/mapbox/Fingertips'
+  f.license          = 'BSD'
+  f.author           = { 'Mapbox' => 'mobile@mapbox.com' }
+  f.social_media_url = 'https://twitter.com/Mapbox'
 
   f.source = { :git => 'https://github.com/mapbox/Fingertips.git', :tag => f.version.to_s }
 


### PR DESCRIPTION
- Delete the deprecated `documentation` attribute
  - It’s now automatically handled by [CocoaDocs](http://cocoadocs.org/docsets/Fingertips/0.3.0/)
- Change homepage to https instead of http
  - So that `pod spec lint` is happy
- Add `social_media_url` DSL directive
  - So that @CocoaPodsFeed can mention @Mapbox
