### PR TITLE
Fix status bar hiding in iOS 7.

### DIFF
--- a/MBFingerTipWindow.m
+++ b/MBFingerTipWindow.m
@@ -187,6 +187,11 @@
 #pragma mark -
 #pragma mark UIWindow overrides
 
+- (void)setRootViewController:(UIViewController *)rootViewController {
+    [super setRootViewController:rootViewController];
+    [self.overlayWindow setRootViewController:rootViewController];
+}
+
 - (void)sendEvent:(UIEvent *)event
 {
     if (self.active)


### PR DESCRIPTION
It seems that, when calling the new iOS 7 status bar functions, the
application looks for the window with the highest level and works
with that window's rootViewController.

So, echo the window's rootViewController into its overlayWindow.

Fixes #12.
