### PR TITLE
Alternate fix for overlay window in Fingertips.

### DIFF
--- a/MBFingerTipWindow.m
+++ b/MBFingerTipWindow.m
@@ -22,6 +22,11 @@
 
 #pragma mark -
 
+@interface MBFingerTipOverlayWindow : UIWindow
+@end
+
+#pragma mark -
+
 @interface MBFingerTipWindow ()
 
 @property (nonatomic, strong) UIWindow *overlayWindow;
@@ -104,7 +109,7 @@
 {
     if ( ! _overlayWindow)
     {
-        _overlayWindow = [[UIWindow alloc] initWithFrame:self.frame];
+        _overlayWindow = [[MBFingerTipOverlayWindow alloc] initWithFrame:self.frame];
         
         _overlayWindow.userInteractionEnabled = NO;
         _overlayWindow.windowLevel = UIWindowLevelStatusBar;
@@ -357,5 +362,28 @@
 #pragma mark -
 
 @implementation MBFingerTipView
+
+@end
+
+#pragma mark -
+
+@implementation MBFingerTipOverlayWindow
+
+// UIKit tries to get the rootViewController from the overlay window.
+// Instead, try to find the rootViewController on some other
+// application window.
+// Fixes problems with status bar hiding, because it considers the
+// overlay window a candidate for controlling the status bar.
+- (UIViewController *)rootViewController {
+    for (UIWindow *window in [[UIApplication sharedApplication] windows]) {
+        if (self == window)
+            continue;
+
+        UIViewController *realRootViewController = window.rootViewController;
+        if (realRootViewController != nil)
+            return realRootViewController;
+    }
+    return [super rootViewController];
+}
 
 @end


### PR DESCRIPTION
Second time's a charm? A different fix for the status bar not hiding.

If UIKit asks the overlay window for the root view controller, look
through the application window list for a better candidate for that
controller, and return that instead.

From tracing method calls, UIKit returns the top window that 
"_canAffectStatusBarAppearance", apparently checking the bundle of
the class to see if it's an internal window, checking the screen
of the window, and checking the window level.

Attempts to set the window level to all kinds of numbers had failed.

The previous fix, which overrode the setRootViewController method of the
main window, caused problems with touch events not being delivered to
some apps.

Fixes #12
