### PR TITLE
Remove the alwaysShowTouches property

### DIFF
--- a/MBFingerTipWindow.h
+++ b/MBFingerTipWindow.h
@@ -26,7 +26,4 @@
 /** If using the default touchImage, the color with whicih to fill the shape. Defaults to white. */
 @property (nonatomic, strong) UIColor *fillColor;
 
-/** Sets whether touches should always show regardless of whether the display is mirroring. Defaults to NO. */
-@property (nonatomic, assign) BOOL alwaysShowTouches;
-
 @end

--- a/MBFingerTipWindow.m
+++ b/MBFingerTipWindow.m
@@ -152,18 +152,6 @@
     return _touchImage;
 }
 
-#pragma mark - Setter
-
-- (void)setAlwaysShowTouches:(BOOL)flag
-{
-	if (_alwaysShowTouches != flag)
-	{
-		_alwaysShowTouches = flag;
-
-        [self updateFingertipsAreActive];
-	}
-}
-
 #pragma mark -
 #pragma mark Screen notifications
 
@@ -193,7 +181,7 @@
 
 - (void)updateFingertipsAreActive;
 {
-    if (self.alwaysShowTouches || ([[[[NSProcessInfo processInfo] environment] objectForKey:@"DEBUG_FINGERTIP_WINDOW"] boolValue]))
+    if ([[[[NSProcessInfo processInfo] environment] objectForKey:@"DEBUG_FINGERTIP_WINDOW"] boolValue])
     {
         self.active = YES;
     }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ You shouldn't need to configure anything, but if you want to tweak some knobs:
  * `strokeColor`: change default `touchImage` stroke color (defaults to black)
  * `fillColor`: change default `touchImage` fill color (defaults to white)
 
-If you ever need to debug Fingertips, just set the `DEBUG_FINGERTIP_WINDOW` environment variable to `YES` in Xcode.
+If you ever need to debug Fingertips, i.e. always show touches even when no mirroring is active, set the `DEBUG_FINGERTIP_WINDOW` [environment variable](http://stackoverflow.com/questions/17393053/xcode-4-6-where-to-set-environment-variables-for-app/17394454#17394454) to `YES` in Xcode. If you want to always show touches, even in release mode, just add this line of code.
+
+```objc
+setenv("DEBUG_FINGERTIP_WINDOW", "YES", 1);
+```
 
 ## License
 


### PR DESCRIPTION
Always showing touches can be achieved with the `DEBUG_FINGERTIP_WINDOW` environment variable, clarify that in the README.