### PR TITLE
Fix prefix in header import

### DIFF
--- a/Fingertips.h
+++ b/Fingertips.h
@@ -13,6 +13,6 @@ FOUNDATION_EXPORT double FingertipsVersionNumber;
 //! Project version string for Fingertips.
 FOUNDATION_EXPORT const unsigned char FingertipsVersionString[];
 
-#import <Fingertips/MPFingerTipWindow.h>
+#import <Fingertips/MBFingerTipWindow.h>
 
 


### PR DESCRIPTION
Well this is embarrassing. I misspelled the name of the header in #24. Somehow Xcode didn’t error when I built this. But when I tried to integrate it in my project today, I got an error.