### PR TITLE
Fix status bar appearance issues

### DIFF
--- a/MBFingerTipWindow.m
+++ b/MBFingerTipWindow.m
@@ -385,22 +385,12 @@
 
 @implementation MBFingerTipOverlayWindow
 
-// UIKit tries to get the rootViewController from the overlay window.
-// Instead, try to find the rootViewController on some other application window.
-// Fixes problems with status bar hiding, because it considers the overlay window a candidate for controlling the status bar.
+// UIKit tries to get the rootViewController from the overlay window. Use the key window instead. This fixes
+// issues with status bar behavior, as otherwise the overlay window would control the status bar
 
 - (UIViewController *)rootViewController
 {
-    for (UIWindow *window in [[UIApplication sharedApplication] windows])
-    {
-        if (self == window)
-            continue;
-
-        UIViewController *realRootViewController = window.rootViewController;
-        if (realRootViewController != nil)
-            return realRootViewController;
-    }
-    return [super rootViewController];
+    return [UIApplication sharedApplication].keyWindow.rootViewController ?: [super rootViewController];
 }
 
 @end

--- a/MBFingerTipWindow.m
+++ b/MBFingerTipWindow.m
@@ -385,12 +385,16 @@
 
 @implementation MBFingerTipOverlayWindow
 
-// UIKit tries to get the rootViewController from the overlay window. Use the key window instead. This fixes
+// UIKit tries to get the rootViewController from the overlay window. Use the Fingertips window instead. This fixes
 // issues with status bar behavior, as otherwise the overlay window would control the status bar
 
 - (UIViewController *)rootViewController
 {
-    return [UIApplication sharedApplication].keyWindow.rootViewController ?: [super rootViewController];
+    NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary *bindings) {
+        return [evaluatedObject isKindOfClass:[MBFingerTipWindow class]];
+    }];
+    UIWindow *mainWindow = [[UIApplication sharedApplication].windows filteredArrayUsingPredicate:predicate].firstObject;
+    return mainWindow.rootViewController ?: [super rootViewController];
 }
 
 @end

--- a/MBFingerTipWindow.m
+++ b/MBFingerTipWindow.m
@@ -386,14 +386,15 @@
 @implementation MBFingerTipOverlayWindow
 
 // UIKit tries to get the rootViewController from the overlay window. Use the Fingertips window instead. This fixes
-// issues with status bar behavior, as otherwise the overlay window would control the status bar
+// issues with status bar behavior, as otherwise the overlay window would control the status bar.
 
 - (UIViewController *)rootViewController
 {
-    NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary *bindings) {
+    NSPredicate *predicate = [NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary *bindings)
+    {
         return [evaluatedObject isKindOfClass:[MBFingerTipWindow class]];
     }];
-    UIWindow *mainWindow = [[UIApplication sharedApplication].windows filteredArrayUsingPredicate:predicate].firstObject;
+    UIWindow *mainWindow = [[[[UIApplication sharedApplication] windows] filteredArrayUsingPredicate:predicate] firstObject];
     return mainWindow.rootViewController ?: [super rootViewController];
 }
 


### PR DESCRIPTION
Hi!

The way the Fingertips overlay resolves the root view controller to act in behalf of leads to issues depending on the involved window hierarchy. This might incorrectly defer status bar responsibility to root view controllers of secret windows instantiated by the system.

In a usual application, the window hierarchy looks as follows:

```
<__NSArrayM 0x126f261c0>(
<MBFingerTipWindow: 0x126e46470; baseClass = UIWindow; frame = (0 0; 768 1024); autoresize = W+H; gestureRecognizers = <NSArray: 0x126e48b50>; layer = <UIWindowLayer: 0x126d2d7f0>>,
<MBFingerTipOverlayWindow: 0x126dbf9a0; baseClass = UIWindow; frame = (0 0; 768 1024); userInteractionEnabled = NO; gestureRecognizers = <NSArray: 0x126dc1d90>; layer = <UIWindowLayer: 0x126d628c0>>
)
```

If this application instantiates a picture in picture controller (`AVPictureInPictureController`) , though, the window hierarchy changes to the following one, even if picture in picture is not enabled (instantiation suffices):

```
<__NSArrayM 0x126f261c0>(
<PGHostedWindow: 0x126ec4b40; baseClass = _UIHostedWindow; frame = (0 0; 768 1024); gestureRecognizers = <NSArray: 0x126f30cb0>; layer = <UIWindowLayer: 0x126ef0920>>,
<MBFingerTipWindow: 0x126e46470; baseClass = UIWindow; frame = (0 0; 768 1024); autoresize = W+H; gestureRecognizers = <NSArray: 0x126e48b50>; layer = <UIWindowLayer: 0x126d2d7f0>>,
<UITextEffectsWindow: 0x126d97190; frame = (0 0; 768 1024); opaque = NO; autoresize = W+H; layer = <UIWindowLayer: 0x126d97760>>,
<MBFingerTipOverlayWindow: 0x126dbf9a0; baseClass = UIWindow; frame = (0 0; 768 1024); userInteractionEnabled = NO; gestureRecognizers = <NSArray: 0x126dc1d90>; layer = <UIWindowLayer: 0x126d628c0>>
)
```

In such cases, `-[MBFingerTipOverlayWindow rootViewController]` returns the `UITextEffectsWindow` root view controller as result, instead of the `MBFingerTipWindow` we would have expected. The status bar settings of this hidden system view controller are default ones (black appearance, for example) and settings made at the application level (view controller belonging to the key window) are lost. You cannot therefore have a white status bar as soon a picture in picture controller has been instantiated, for example.

To solve such issues, the root view controller which `MBFingerTipOverlayWindow` pretends to have should be the key window root view controller. This way, the Fingertips overlay can transparently return the application status bar settings.

Thanks in advance for taking the time to look at this pull request.

Best regards.
