### PR TITLE
Fix iOS builds on Xcode 11.4 for new enum values added in iOS 13.4.

### DIFF
--- a/MBFingerTipWindow.m
+++ b/MBFingerTipWindow.m
@@ -251,6 +251,9 @@
                     [self removeFingerTipWithHash:touch.hash animated:YES];
                     break;
                 }
+                default:
+                    // Handle the `UITouchPhaseRegion`... enum values.
+                    break;
             }
         }
     }


### PR DESCRIPTION
The following issues have been filed to track the handling of these enum values: #38 

No change in functionality. Only makes the iOS engine build on the latest versions of Xcode and iOS SDK.